### PR TITLE
Update APIService.js

### DIFF
--- a/movie_fe/movie-fe/src/http/APIService.js
+++ b/movie_fe/movie-fe/src/http/APIService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = 'http://cloudmind.pythonanywhere.com/'
+const API_URL = 'https://cloudmind.pythonanywhere.com/'
 
 export class APIService {
     constructor() {


### PR DESCRIPTION
Login feature doesn't work in the deployed website (https://peaceful-visvesvaraya-4f45d4.netlify.app/auth).

Fixed the error that occurred in the Login page - "The page at 'https://peaceful-visvesvaraya-4f45d4.netlify.app/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://cloudmind.pythonanywhere.com//api/movies/'. This request has been blocked; the content must be served over HTTPS."

Made the following changes:
Before: const API_URL = 'http://cloudmind.pythonanywhere.com/'
After: const API_URL = 'http**s**://cloudmind.pythonanywhere.com/'